### PR TITLE
parser: don't format runtime errors as test failures.

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -779,10 +779,6 @@ module XCPretty
       @formatting_runtime_error = false
       formatter.format_runtime_error(runtime_error[:sanitizer],
                                      runtime_error[:reason], "")
-      formatter.format_failing_test(guess_test_suite,
-                                    guess_test_case,
-                                    "#{runtime_error[:sanitizer]} #{runtime_error[:reason]}",
-                                    runtime_error[:info])
     end
 
     def format_undefined_duplicate_symbols


### PR DESCRIPTION
The test failure format was originally added in a time when UBSan did
not fail tests, and junit reports were generated by xcpretty. Failing
the test cosmetically in xcpretty was the indication that there was
a runtime error but the tests itself still passed.

This commit fixes the situation by printing the runtime error itself.
Failing the test is not the business of xcpretty.