### PR TITLE
Add options to show unmatched lines in output

### DIFF
--- a/bin/xcpretty
+++ b/bin/xcpretty
@@ -29,7 +29,8 @@ report_formats = {
 printer_opts = {
   unicode: XCPretty::Term.unicode?,
   colorize: XCPretty::Term.color?,
-  formatter: XCPretty::Simple
+  formatter: XCPretty::Simple,
+  unmatched: XCPretty::Term.unmatched?
 }
 
 OptionParser.new do |opts|
@@ -51,6 +52,9 @@ OptionParser.new do |opts|
   end
   opts.on('--[no-]utf', 'Use unicode characters in output. Default is auto.') do |value|
     printer_opts[:unicode] = value
+  end
+  opts.on('--[no-]unmatched', 'Show unmatched lines in output. Default is false.') do |value|
+    printer_opts[:unmatched] = value
   end
   opts.on("-r", "--report FORMAT", "Run FORMAT reporter",
           "  Choices: #{report_formats.keys.join(', ')}") do |format|

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -93,9 +93,10 @@ module XCPretty
 
     attr_reader :parser
 
-    def initialize(use_unicode, colorize)
+    def initialize(use_unicode, colorize, unmatched)
       @use_unicode = use_unicode
       @colorize = colorize
+      @unmatched = unmatched
       @parser = Parser.new(self)
     end
 
@@ -113,6 +114,10 @@ module XCPretty
 
     def use_unicode?
       !!@use_unicode
+    end
+
+    def unmatched?
+      !!@unmatched
     end
 
     # Will be printed by default. Override with '' if you don't want summary
@@ -173,9 +178,12 @@ module XCPretty
     end
 
     def format_other(text)
-      ""
+      if @unmatched && text && !text.empty? && !text.gsub(/\s+/, '').empty?
+        "unmatched: " + text.rstrip
+      else
+        ""
+      end
     end
-
 
     private
 

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -6,7 +6,7 @@ module XCPretty
 
     attr_reader :counter
 
-    def initialize(unicode, color)
+    def initialize(unicode, color, unmatched)
       super
       @counter = 0
     end

--- a/lib/xcpretty/printer.rb
+++ b/lib/xcpretty/printer.rb
@@ -10,7 +10,7 @@ module XCPretty
 
     def initialize(params)
       klass = params[:formatter]
-      @formatter = klass.new(params[:unicode], params[:colorize])
+      @formatter = klass.new(params[:unicode], params[:colorize], params[:unmatched])
     end
 
     def finish

--- a/lib/xcpretty/reporters/reporter.rb
+++ b/lib/xcpretty/reporters/reporter.rb
@@ -15,7 +15,7 @@ module XCPretty
     end
 
     def initialize(options)
-      super(true, true)
+      super(true, true, false)
       load_dependencies
       @filepath = options[:path] || self.class::FILEPATH
       @test_count = 0

--- a/lib/xcpretty/term.rb
+++ b/lib/xcpretty/term.rb
@@ -10,5 +10,9 @@ module XCPretty
     def self.color?
       STDOUT.tty?
     end
+
+    def self.unmatched?
+      false
+    end
   end
 end

--- a/spec/xcpretty/formatters/formatter_spec.rb
+++ b/spec/xcpretty/formatters/formatter_spec.rb
@@ -8,7 +8,7 @@ module XCPretty
   describe Formatter do
 
     before(:each) do
-      @formatter = Formatter.new(true, true)
+      @formatter = Formatter.new(true, true, false)
     end
 
     it "initializes with unicode" do
@@ -17,6 +17,10 @@ module XCPretty
 
     it "initializes with color" do
       @formatter.colorize?.should == true
+    end
+
+    it "initializes with @unmatched = false" do
+      @formatter.unmatched?.should == false
     end
 
     it "outputs to new lines by default" do
@@ -152,5 +156,15 @@ UI spec
 
 #{@formatter.red(SAMPLE_EXECUTED_TESTS)})
     end
+
+    it "show unmatched lines with @unmatched = true" do
+      @formatter = Formatter.new(true, true, true)
+      @formatter.format_other(SAMPLE_FORMAT_OTHER_UNRECOGNIZED_STRING).should == "unmatched: " + SAMPLE_FORMAT_OTHER_UNRECOGNIZED_STRING
+    end
+
+    it "hide unmatched lines with @unmatched = false" do
+      @formatter.format_other(SAMPLE_FORMAT_OTHER_UNRECOGNIZED_STRING).should == ""
+    end
+
   end
 end

--- a/spec/xcpretty/formatters/rspec_spec.rb
+++ b/spec/xcpretty/formatters/rspec_spec.rb
@@ -9,7 +9,7 @@ module XCPretty
   describe RSpec do
 
     before(:each) do
-      @formatter = RSpec.new(false, false)
+      @formatter = RSpec.new(false, false, false)
     end
 
     it "prints dots in the same line" do

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -9,7 +9,7 @@ module XCPretty
     describe Simple do
 
       before(:each) do
-        @formatter = Simple.new(false, false)
+        @formatter = Simple.new(false, false, false)
       end
 
       it "formats analyzing" do

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -9,7 +9,7 @@ module XCPretty
   describe Parser do
 
     before(:each) do
-      @formatter = Formatter.new(false, false)
+      @formatter = Formatter.new(false, false, false)
       @parser = Parser.new(@formatter)
     end
 

--- a/spec/xcpretty/printer_spec.rb
+++ b/spec/xcpretty/printer_spec.rb
@@ -40,9 +40,10 @@ end
 module XCPretty
   class DummyFormatter < Formatter
 
-    def initialize(unicode, colorize)
+    def initialize(unicode, colorize, unmatched)
       @use_unicode = unicode
       @colorize = colorize
+      @unmatched = unmatched
     end
 
     def pretty_format(text)


### PR DESCRIPTION
The idea behind this is to be able to easily determine which lines are "not shown" when expecting for one in output.

For example, when running tests on multiple destinations, there is a "on 'DeviceName'" part on the lines:

```
unmatched: Test case 'UserTests.testDisplayName_firstnameAndLastname()' passed on 'iPhone-XS-Max' (0.001 seconds)
unmatched: Test case 'UserTests.testDisplayName_firstnameAndNickname()' passed on 'iPhone-XS-Max' (0.001 seconds)
```